### PR TITLE
FallbackResource directive works for any URI except `/`

### DIFF
--- a/provision/apache_config
+++ b/provision/apache_config
@@ -4,6 +4,7 @@
         <Directory /var/www/web/>
                 Options Indexes FollowSymLinks MultiViews
                 AllowOverride All
+                DirectoryIndex /index.php
                 FallbackResource /index.php
                 Order allow,deny
                 Allow from all


### PR DESCRIPTION
http://serverfault.com/questions/512735/fallbackresource-directive-works-for-any-uri-except
